### PR TITLE
[#7] Color assets 추가

### DIFF
--- a/MoMo/MoMo.xcodeproj/project.pbxproj
+++ b/MoMo/MoMo.xcodeproj/project.pbxproj
@@ -13,10 +13,11 @@
 		568764142599AD3A009CB486 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 568764122599AD3A009CB486 /* Main.storyboard */; };
 		568764162599AD3C009CB486 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 568764152599AD3C009CB486 /* Assets.xcassets */; };
 		568764192599AD3C009CB486 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 568764172599AD3C009CB486 /* LaunchScreen.storyboard */; };
-		568764242599E32B009CB486 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 568764232599E32B009CB486 /* Colors.xcassets */; };
 		568764362599EEC9009CB486 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 568764352599EEC9009CB486 /* .swiftlint.yml */; };
 		5687645E2599FB48009CB486 /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5687645D2599FB48009CB486 /* AppConstants.swift */; };
 		568764612599FB56009CB486 /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568764602599FB56009CB486 /* APIConstants.swift */; };
+		568764CE259F6A80009CB486 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 568764CD259F6A80009CB486 /* Colors.xcassets */; };
+		568764D1259F6EDE009CB486 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568764D0259F6EDE009CB486 /* UIColor+Extension.swift */; };
 		9360320992DCEB38E63381C5 /* Pods_MoMo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FCF70C440F3CE67275FF3023 /* Pods_MoMo.framework */; };
 /* End PBXBuildFile section */
 
@@ -29,10 +30,11 @@
 		568764152599AD3C009CB486 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		568764182599AD3C009CB486 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		5687641A2599AD3C009CB486 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		568764232599E32B009CB486 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		568764352599EEC9009CB486 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		5687645D2599FB48009CB486 /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 		568764602599FB56009CB486 /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
+		568764CD259F6A80009CB486 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		568764D0259F6EDE009CB486 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		596A64056F40D8E627DE76D5 /* Pods-MoMo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoMo.debug.xcconfig"; path = "Target Support Files/Pods-MoMo/Pods-MoMo.debug.xcconfig"; sourceTree = "<group>"; };
 		BC74336F4AB884589C6C3095 /* Pods-MoMo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoMo.release.xcconfig"; path = "Target Support Files/Pods-MoMo/Pods-MoMo.release.xcconfig"; sourceTree = "<group>"; };
 		FCF70C440F3CE67275FF3023 /* Pods_MoMo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MoMo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,7 +85,7 @@
 			children = (
 				5687641A2599AD3C009CB486 /* Info.plist */,
 				568764152599AD3C009CB486 /* Assets.xcassets */,
-				568764232599E32B009CB486 /* Colors.xcassets */,
+				568764CD259F6A80009CB486 /* Colors.xcassets */,
 				5687645B2599FB39009CB486 /* Constants */,
 				5687642B2599E36B009CB486 /* Storyboards */,
 			);
@@ -116,6 +118,7 @@
 		568764282599E33F009CB486 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				568764D0259F6EDE009CB486 /* UIColor+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -251,9 +254,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				568764CE259F6A80009CB486 /* Colors.xcassets in Resources */,
 				568764362599EEC9009CB486 /* .swiftlint.yml in Resources */,
 				568764192599AD3C009CB486 /* LaunchScreen.storyboard in Resources */,
-				568764242599E32B009CB486 /* Colors.xcassets in Resources */,
 				568764162599AD3C009CB486 /* Assets.xcassets in Resources */,
 				568764142599AD3A009CB486 /* Main.storyboard in Resources */,
 			);
@@ -330,6 +333,7 @@
 				568764112599AD3A009CB486 /* ViewController.swift in Sources */,
 				568764612599FB56009CB486 /* APIConstants.swift in Sources */,
 				5687640D2599AD3A009CB486 /* AppDelegate.swift in Sources */,
+				568764D1259F6EDE009CB486 /* UIColor+Extension.swift in Sources */,
 				5687640F2599AD3A009CB486 /* SceneDelegate.swift in Sources */,
 				5687645E2599FB48009CB486 /* AppConstants.swift in Sources */,
 			);

--- a/MoMo/MoMo/Resources/Colors.xcassets/Black1.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Black1.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.122",
+          "green" : "0.122",
+          "red" : "0.122"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.122",
+          "green" : "0.122",
+          "red" : "0.122"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Black2Nav.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Black2Nav.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.235",
+          "green" : "0.235",
+          "red" : "0.235"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.235",
+          "green" : "0.235",
+          "red" : "0.235"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Black3List.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Black3List.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.278",
+          "green" : "0.278",
+          "red" : "0.278"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.278",
+          "green" : "0.278",
+          "red" : "0.278"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Black4.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Black4.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.455",
+          "green" : "0.455",
+          "red" : "0.455"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.455",
+          "green" : "0.455",
+          "red" : "0.455"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Black5Publish.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Black5Publish.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.565",
+          "green" : "0.565",
+          "red" : "0.565"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.565",
+          "green" : "0.565",
+          "red" : "0.565"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Black6.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Black6.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.831",
+          "green" : "0.831",
+          "red" : "0.831"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.831",
+          "green" : "0.831",
+          "red" : "0.831"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Blue1.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Blue1.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.659",
+          "green" : "0.404",
+          "red" : "0.192"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.659",
+          "green" : "0.404",
+          "red" : "0.192"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Blue2.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Blue2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.722",
+          "green" : "0.482",
+          "red" : "0.278"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.722",
+          "green" : "0.482",
+          "red" : "0.278"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Blue3.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Blue3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.847",
+          "green" : "0.627",
+          "red" : "0.447"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.847",
+          "green" : "0.627",
+          "red" : "0.447"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Blue4.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Blue4.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.918",
+          "green" : "0.796",
+          "red" : "0.698"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.918",
+          "green" : "0.796",
+          "red" : "0.698"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Blue5.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Blue5.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.937",
+          "green" : "0.843",
+          "red" : "0.765"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.937",
+          "green" : "0.843",
+          "red" : "0.765"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Blue6.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Blue6.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.984",
+          "green" : "0.937",
+          "red" : "0.902"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.984",
+          "green" : "0.937",
+          "red" : "0.902"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Blue7.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Blue7.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.976",
+          "red" : "0.961"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.976",
+          "red" : "0.961"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/BlueModalAble.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/BlueModalAble.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.722",
+          "green" : "0.541",
+          "red" : "0.384"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.722",
+          "green" : "0.541",
+          "red" : "0.384"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/LineFilterGray.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/LineFilterGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.890",
+          "green" : "0.890",
+          "red" : "0.890"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.890",
+          "green" : "0.890",
+          "red" : "0.890"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/LineLightGray.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/LineLightGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.878",
+          "green" : "0.878",
+          "red" : "0.878"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.878",
+          "green" : "0.878",
+          "red" : "0.878"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/ListBlack.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/ListBlack.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.278",
+          "green" : "0.278",
+          "red" : "0.278"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.278",
+          "green" : "0.278",
+          "red" : "0.278"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/ListEmotion.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/ListEmotion.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.686",
+          "green" : "0.533",
+          "red" : "0.455"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.686",
+          "green" : "0.533",
+          "red" : "0.455"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/ListLightBlack.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/ListLightBlack.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.349",
+          "green" : "0.349",
+          "red" : "0.349"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.349",
+          "green" : "0.349",
+          "red" : "0.349"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/ListSubGray.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/ListSubGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.565",
+          "green" : "0.565",
+          "red" : "0.565"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.565",
+          "green" : "0.565",
+          "red" : "0.565"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/NavWhite.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/NavWhite.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.863",
+          "green" : "0.827",
+          "red" : "0.796"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.863",
+          "green" : "0.827",
+          "red" : "0.796"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Resources/Colors.xcassets/TitleNavy.colorset/Contents.json
+++ b/MoMo/MoMo/Resources/Colors.xcassets/TitleNavy.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.384",
+          "green" : "0.251",
+          "red" : "0.184"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.384",
+          "green" : "0.251",
+          "red" : "0.184"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MoMo/MoMo/Sources/Extensions/UIColor+Extension.swift
+++ b/MoMo/MoMo/Sources/Extensions/UIColor+Extension.swift
@@ -1,0 +1,34 @@
+//
+//  UIColor+Extension.swift
+//  MoMo
+//
+//  Created by 초이 on 2021/01/01.
+//
+
+import Foundation
+import UIKit
+
+extension UIColor {
+    static let Black1: UIColor = UIColor(named: "Black1")!
+    static let Black2Nav: UIColor = UIColor(named: "Black2Nav")!
+    static let Black3List: UIColor = UIColor(named: "Black3List")!
+    static let Black4: UIColor = UIColor(named: "Black4")!
+    static let Black5Publish: UIColor = UIColor(named: "Black5Publish")!
+    static let Black6: UIColor = UIColor(named: "Black6")!
+    static let Blue1: UIColor = UIColor(named: "Blue1")!
+    static let Blue2: UIColor = UIColor(named: "Blue2")!
+    static let Blue3: UIColor = UIColor(named: "Blue3")!
+    static let Blue4: UIColor = UIColor(named: "Blue4")!
+    static let Blue5: UIColor = UIColor(named: "Blue5")!
+    static let Blue6: UIColor = UIColor(named: "Blue6")!
+    static let Blue7: UIColor = UIColor(named: "Blue7")!
+    static let BlueModalAble: UIColor = UIColor(named: "BlueModalAble")!
+    static let LineFilterGray: UIColor = UIColor(named: "LineFilterGray")!
+    static let LineLightGray: UIColor = UIColor(named: "LineLightGray")!
+    static let ListBlack: UIColor = UIColor(named: "ListBlack")!
+    static let ListEmotion: UIColor = UIColor(named: "ListEmotion")!
+    static let ListLightBlack: UIColor = UIColor(named: "ListLightBlack")!
+    static let ListSubGray: UIColor = UIColor(named: "ListSubGray")!
+    static let NavWhite: UIColor = UIColor(named: "NavWhite")!
+    static let TitleNavy: UIColor = UIColor(named: "TitleNavy")!
+}


### PR DESCRIPTION
### Description
![image](https://user-images.githubusercontent.com/28949235/103441070-bc1cc080-4c8e-11eb-808e-1cbc64a0022a.png)
제플린 Styleguide에 업로드 된 Color Palette 색상들 Colors.xcassets에 추가했습니다!
깔끔한 코드를 위해 UIColor의 Extension으로 static 상수들도 선언 해 놨어요.

사용하실 땐 `UIColor.Black1` 이렇게 사용하시면 됩니다.
자세한 사용법은 [여기](https://iamcho2.github.io/2021/01/01/use-color-assets) 참고하세요!

### Related Issues
Fixes #7 