### PR TITLE
[#302] EmailLoginView에서 로그인에 실패할 경우 로딩 인디케이터가 계속 보이는 문제해결

### DIFF
--- a/MoMo/MoMo/Sources/ViewControllers/EmailLoginViewController.swift
+++ b/MoMo/MoMo/Sources/ViewControllers/EmailLoginViewController.swift
@@ -158,6 +158,11 @@ extension EmailLoginViewController {
                     }
                 }
             case .requestErr(let msg):
+                
+                if self.activityIndicator.isAnimating {
+                    self.activityIndicator.stopAnimating()
+                }
+                
                 if let _ = msg as? String {
                     self.errorMessageTop.constant = 76
                     self.errorMessageLabel.isHidden = false

--- a/MoMo/MoMo/Sources/ViewControllers/EmailLoginViewController.swift
+++ b/MoMo/MoMo/Sources/ViewControllers/EmailLoginViewController.swift
@@ -101,11 +101,8 @@ class EmailLoginViewController: UIViewController {
     private func detachActivityIndicator() {
         if self.activityIndicator.isAnimating {
             self.activityIndicator.stopAnimating()
-            self.activityIndicator.removeFromSuperview()
-        } else {
-            self.activityIndicator.removeFromSuperview()
         }
-        
+        self.activityIndicator.removeFromSuperview()
     }
     
     @objc private func touchNavigationButton(sender: Any) {

--- a/MoMo/MoMo/Sources/ViewControllers/EmailLoginViewController.swift
+++ b/MoMo/MoMo/Sources/ViewControllers/EmailLoginViewController.swift
@@ -94,6 +94,20 @@ class EmailLoginViewController: UIViewController {
         self.navigationController?.popViewController(animated: true)
     }
     
+    private func attachActivityIndicator() {
+        self.view.addSubview(self.activityIndicator)
+    }
+    
+    private func detachActivityIndicator() {
+        if self.activityIndicator.isAnimating {
+            self.activityIndicator.stopAnimating()
+            self.activityIndicator.removeFromSuperview()
+        } else {
+            self.activityIndicator.removeFromSuperview()
+        }
+        
+    }
+    
     @objc private func touchNavigationButton(sender: Any) {
         if let button = sender as? UIBarButtonItem {
             switch button.tag {
@@ -108,7 +122,7 @@ class EmailLoginViewController: UIViewController {
     // MARK: - @IBAction Properties
     
     @IBAction func touchUpLoginButton(_ sender: Any) {
-        self.view.addSubview(self.activityIndicator)
+        self.attachActivityIndicator()
         self.postSignInWithAPI(completion: self.pushToHomeViewController)
     }
     
@@ -149,9 +163,7 @@ extension EmailLoginViewController {
                     UserDefaults.standard.setValue(signInData.user.id, forKey: "userId")
                     UserDefaults.standard.setValue("email", forKey: "loginType")
                     
-                    if self.activityIndicator.isAnimating {
-                        self.activityIndicator.stopAnimating()
-                    }
+                    self.detachActivityIndicator()
                     
                     DispatchQueue.main.async {
                         completion()
@@ -159,9 +171,7 @@ extension EmailLoginViewController {
                 }
             case .requestErr(let msg):
                 
-                if self.activityIndicator.isAnimating {
-                    self.activityIndicator.stopAnimating()
-                }
+                self.detachActivityIndicator()
                 
                 if let _ = msg as? String {
                     self.errorMessageTop.constant = 76


### PR DESCRIPTION
### Description
https://user-images.githubusercontent.com/20268101/108615578-f3b31800-7448-11eb-80c0-5bd6f9bccba8.mov
### Related Issues
Fixes #302 


